### PR TITLE
Fix path to mesh in URDF

### DIFF
--- a/submitted_models/ctu_cras_norlab_x500_sensor_config_1/urdf/model.xacro
+++ b/submitted_models/ctu_cras_norlab_x500_sensor_config_1/urdf/model.xacro
@@ -71,13 +71,13 @@
     <visual name='base_link_fixed_joint_lump__rs_up_visual_visual'>
       <origin xyz='0.082 0 0.034' rpy='-1.5708 0 1.5708'/>
       <geometry>
-        <mesh filename='package://ctu_cras_norlab_x500_sensor_config_1/meshes/realsense.dae' scale='1 1 1'/>
+        <mesh filename='package://ctu_cras_norlab_x500_sensor_config_1/meshes/sensors/realsense.dae' scale='1 1 1'/>
       </geometry>
     </visual>
     <visual name='base_link_fixed_joint_lump__rs_down_visual_visual_1'>
       <origin xyz='0.085 0 -0.02' rpy='1.5708 -0 1.5708'/>
       <geometry>
-        <mesh filename='package://ctu_cras_norlab_x500_sensor_config_1/meshes/realsense.dae' scale='1 1 1'/>
+        <mesh filename='package://ctu_cras_norlab_x500_sensor_config_1/meshes/sensors/realsense.dae' scale='1 1 1'/>
       </geometry>
     </visual>
     <visual name='base_link_fixed_joint_lump__camera_front_visual_2'>


### PR DESCRIPTION
Without this PR, rviz is complaining:

```
[ WARN] [1615249969.997585820, 64.988000000] [ros.rviz]: OGRE EXCEPTION(6:FileNotFoundException): Cannot locate resource package://ctu_cras_norlab_x500_sensor_config_1/meshes/realsense.dae in resource group Autodetect or any other group. in ResourceGroupManager::openResource at /build/ogre-1.9-B6QkmW/ogre-1.9-1.9.0+dfsg1/OgreMain/src/OgreResourceGroupManager.cpp (line 756)
[ERROR] [1615249969.997727527, 64.988000000] [ros.rviz]: Could not load model 'package://ctu_cras_norlab_x500_sensor_config_1/meshes/realsense.dae' for link 'X1/base_link': OGRE EXCEPTION(6:FileNotFoundException): Cannot locate resource package://ctu_cras_norlab_x500_sensor_config_1/meshes/realsense.dae in resource group Autodetect or any other group. in ResourceGroupManager::openResource at /build/ogre-1.9-B6QkmW/ogre-1.9-1.9.0+dfsg1/OgreMain/src/OgreResourceGroupManager.cpp (line 756)
[ WARN] [1615249969.997808124, 64.988000000] [ros.rviz]: OGRE EXCEPTION(6:FileNotFoundException): Cannot locate resource package://ctu_cras_norlab_x500_sensor_config_1/meshes/realsense.dae in resource group Autodetect or any other group. in ResourceGroupManager::openResource at /build/ogre-1.9-B6QkmW/ogre-1.9-1.9.0+dfsg1/OgreMain/src/OgreResourceGroupManager.cpp (line 756)
[ERROR] [1615249969.997878803, 64.988000000] [ros.rviz]: Could not load model 'package://ctu_cras_norlab_x500_sensor_config_1/meshes/realsense.dae' for link 'X1/base_link': OGRE EXCEPTION(6:FileNotFoundException): Cannot locate resource package://ctu_cras_norlab_x500_sensor_config_1/meshes/realsense.dae in resource group Autodetect or any other group. in ResourceGroupManager::openResource at /build/ogre-1.9-B6QkmW/ogre-1.9-1.9.0+dfsg1/OgreMain/src/OgreResourceGroupManager.cpp (line 756)
```