### PR TITLE
Fix spawning the UAV in example world

### DIFF
--- a/submitted_models/ctu_cras_norlab_x500_sensor_config_1/launch/example.ign
+++ b/submitted_models/ctu_cras_norlab_x500_sensor_config_1/launch/example.ign
@@ -163,7 +163,11 @@
   </executable_wrapper>
   <%end%>
 
+<plugin name="ignition::launch::GazeboFactory"
+        filename="libignition-launch-gazebo-factory.so">
 <%= spawner(robotName, modelURI, $worldName, 0, 0, 0.2, 0, 0, 0) %>
+</plugin>
+   
 <%= rosExecutables(robotName, $worldName) %>
  
 </ignition>


### PR DESCRIPTION
This is needed to actually spawn the UAV in the example.ign.

Test with

    LC_ALL=C ign launch -v 4 /media/data/subt_ws/src/subt/submitted_models/ctu_cras_norlab_x500_sensor_config_1/launch/example.ign robotName:=X1